### PR TITLE
Update profile description and social preview image

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ title: Akshay Nikhare # the main title
 tagline: Shopware 6 Developer<br>Product Design Enthusiast # it will display as the sub-title
 
 description: >- # used by seo meta and the atom feed
-  Experienced Full Stack Developer & Shopware 6 Specialist with 11 years of professional expertise, including 5 years in tech. Skilled in Vue.js, Angular, PHP, MySQL, and product design, delivering high-performance, scalable web solutions. Proficient in eCommerce development, customizing Shopware 6 platform, integrating payment gateways, and third-party APIs. Adept at creating intuitive digital experiences, enhancing application performance, boosting user engagement, and developing effective web scraping tools. Proven ability to lead cross-functional teams, mentor junior developers, and drive projects from concept to completion. Passionate about leveraging cutting-edge technologies, data analytics, and design principles to solve complex problems. Committed to staying updated with the latest industry trends and best practices.
+  Shopware 6 Developer & Full Stack Developer from Nashik, India. 11+ years experience in Vue.js, PHP, MySQL & eCommerce. Expert in plugin development, theme customization & performance optimization.
 
 
 # Fill in the protocol & hostname for your site.
@@ -104,7 +104,7 @@ avatar: "/assets/img/avatar.png"
 
 # The URL of the site-wide social preview image used in SEO `og:image` meta tag.
 # It can be overridden by a customized `page.image` in front matter.
-social_preview_image: # string, local or CORS resources
+social_preview_image: /assets/img/avatar.png
 
 # boolean type, the global switch for TOC in posts.
 toc: true


### PR DESCRIPTION
## Summary
Updated the site configuration to streamline the profile description and configure the social preview image for better SEO.

## Key Changes
- **Profile Description**: Simplified and condensed the bio from a lengthy paragraph to a concise summary highlighting key expertise (Shopware 6, Full Stack Development, location, years of experience, and core technical skills)
- **Social Preview Image**: Set the `social_preview_image` configuration to use the avatar image (`/assets/img/avatar.png`) for SEO meta tags and social sharing

## Details
The description change focuses on clarity and brevity while maintaining the essential information about professional experience and technical expertise. The social preview image configuration ensures that the site's avatar will be used as the default `og:image` for social media sharing and SEO purposes.

https://claude.ai/code/session_01A3fukrxsBrA2sVUuAQiy3c